### PR TITLE
fix: duplicate nav bar and emoji cleanup (SMI-35, SMI-36)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="retro">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Harpi - TTRPG Discord Bot{% endblock %}</title>
+    
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=VT323&family=Share+Tech+Mono&display=swap" rel="stylesheet">
+    
+    <!-- CRT Theme CSS -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/crt-theme.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/components.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/htmx-indicators.css') }}">
+    
+    <!-- HTMX -->
+    <script src="{{ url_for('static', filename='js/htmx.min.js') }}" defer></script>
+    <!-- Alpine.js for minimal interactivity (modals, dropdowns) -->
+    <script src="{{ url_for('static', filename='js/alpine.min.js') }}" defer></script>
+    
+    {% block extra_head %}{% endblock %}
+</head>
+<body>
+    <!-- CRT Scanlines Overlay -->
+    <div class="crt-scanlines" aria-hidden="true"></div>
+    <!-- CRT Vignette -->
+    <div class="crt-vignette" aria-hidden="true"></div>
+    <!-- CRT Curvature -->
+    <div class="crt-curvature" aria-hidden="true"></div>
+    
+    <div class="app-container">
+        <!-- Top Bar -->
+        <header class="top-bar" role="banner">
+            <div class="top-bar-left">
+                 <a class="logo" aria-label="Harpi Home"
+                   hx-get="{{ url_for('html_routes.dashboard') }}"
+                   hx-target="#main-content"
+                   hx-push-url="true"
+                   hx-swap="innerHTML show:window:top"
+                   hx-select="#main-content > *">
+                    <span class="logo-icon">▲</span>
+                    <span class="logo-text">HARPI</span>
+                    <span class="logo-sub">TTRPG BOT</span>
+                </a>
+            </div>
+            
+            <div class="top-bar-center">
+                <nav class="main-nav" role="navigation" aria-label="Main navigation">
+                    <a class="nav-link"
+                       hx-get="{{ url_for('html_routes.dashboard') }}"
+                       hx-target="#main-content"
+                       hx-push-url="true"
+                       hx-swap="innerHTML show:window:top"
+                       hx-select="#main-content > *">
+                        <span class="nav-icon">◢</span>
+                        <span>DASHBOARD</span>
+                    </a>
+                    <a class="nav-link"
+                       hx-get="{{ url_for('html_routes.music_page') }}"
+                       hx-target="#main-content"
+                       hx-push-url="true"
+                       hx-swap="innerHTML show:window:top"
+                       hx-select="#main-content > *">
+                        <span class="nav-icon">♪</span>
+                        <span>MUSIC</span>
+                    </a>
+                    <a class="nav-link"
+                       hx-get="{{ url_for('html_routes.settings_page') }}"
+                       hx-target="#main-content"
+                       hx-select="#main-content > *"
+                       hx-swap="innerHTML show:window:top">
+                        <span class="nav-icon">⚙</span>
+                        <span>SETTINGS</span>
+                    </a>
+                </nav>
+            </div>
+            
+             <div class="top-bar-right">
+                <!-- Guild/Channel Selector -->
+                {% include "partials/_guild_selector.html" %}
+                
+                <!-- Bot Status Indicator -->
+                <div class="bot-status" id="bot-status">
+                    <span class="status-dot {% if bot_connected %}connected{% else %}disconnected{% endif %}" aria-hidden="true"></span>
+                    <span class="status-text">{% if bot_connected %}ONLINE{% else %}OFFLINE{% endif %}</span>
+                </div>
+            </div>
+        </header>
+        
+        <!-- Main Content Area -->
+        <main id="main-content" class="main-content" role="main">
+            {% block content %}
+            {% endblock %}
+        </main>
+        
+        <!-- Footer -->
+        <footer class="app-footer" role="contentinfo">
+            <div class="footer-left">
+                <span class="version">v0.1.0</span>
+                <span class="separator">|</span>
+                <span class="latency" id="latency-display">--ms</span>
+            </div>
+            <div class="footer-center">
+                <span class="crt-label">TVA TEMPAD INTERFACE</span>
+            </div>
+            <div class="footer-right">
+                <span class="time" id="current-time">00:00:00</span>
+            </div>
+        </footer>
+    </div>
+    
+    <!-- Modal Container (Alpine.js) -->
+    <div x-data="{ modalOpen: false, modalContent: '' }" 
+         x-init="window.harpiModal = $refs.modal"
+         class="modal-container" 
+         role="dialog" 
+         aria-modal="true" 
+         aria-labelledby="modal-title"
+         style="display: none;">
+        <div class="modal-overlay" @click="modalOpen = false" aria-hidden="true"></div>
+        <div class="modal-window" role="document" x-ref="modal" x-show="modalOpen" x-transition>
+            <div class="modal-header">
+                <h2 id="modal-title" x-text="modalTitle"></h2>
+                <button class="modal-close" @click="modalOpen = false" aria-label="Close modal">✕</button>
+            </div>
+            <div class="modal-body" x-html="modalContent"></div>
+        </div>
+    </div>
+    
+    <!-- Toast Notifications Container -->
+    <div id="toast-container" class="toast-container" aria-live="polite" aria-atomic="true"></div>
+    
+    <!-- Custom JS -->
+    <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+    
+    {% block extra_scripts %}{% endblock %}
+    
+    <!-- HTMX Configuration -->
+    <script>
+        // Disable HTMX history cache — prevents flicker from cached page restoration
+        htmx.config.historyEnabled = false;
+        
+        // Configure HTMX
+        document.body.addEventListener('htmx:configRequest', (evt) => {
+            // Add CSRF token if needed
+        });
+        
+        // Global HTMX event handlers
+        document.body.addEventListener('htmx:beforeSwap', (evt) => {
+            // Handle error responses
+            if (evt.detail.xhr.status >= 400) {
+                evt.detail.shouldSwap = true;
+                evt.detail.isError = true;
+            }
+        });
+        
+        document.body.addEventListener('htmx:afterSwap', (evt) => {
+            // Re-initialize Alpine.js components in swapped content
+            if (window.Alpine) {
+                window.Alpine.initTree(evt.detail.target);
+            }
+        });
+        
+        // Handle modal opening via HTMX
+        document.body.addEventListener('harpi:open-modal', (evt) => {
+            const modal = document.querySelector('[x-data*="modalOpen"]');
+            if (modal && modal._x_dataStack) {
+                modal._x_dataStack[0].modalOpen = true;
+                modal._x_dataStack[0].modalTitle = evt.detail.title || 'Modal';
+                modal._x_dataStack[0].modalContent = evt.detail.content || '';
+            }
+        });
+        
+        // Handle toast notifications
+        window.showToast = function(message, type = 'info', duration = 5000) {
+            const container = document.getElementById('toast-container');
+            const toast = document.createElement('div');
+            toast.className = `toast toast-${type}`;
+            toast.setAttribute('role', 'alert');
+            toast.innerHTML = `
+                <span class="toast-icon">${type === 'error' ? '✕' : type === 'success' ? '✓' : 'ℹ'}</span>
+                <span class="toast-message">${message}</span>
+                <button class="toast-close" aria-label="Dismiss">✕</button>
+            `;
+            container.appendChild(toast);
+            
+            // Animate in
+            requestAnimationFrame(() => toast.classList.add('show'));
+            
+            // Auto dismiss
+            setTimeout(() => {
+                toast.classList.remove('show');
+                setTimeout(() => toast.remove(), 300);
+            }, duration);
+            
+            // Manual dismiss
+            toast.querySelector('.toast-close').addEventListener('click', () => {
+                toast.classList.remove('show');
+                setTimeout(() => toast.remove(), 300);
+            });
+        };
+    </script>
+</body>
+</html>

--- a/templates/base.html
+++ b/templates/base.html
@@ -112,7 +112,7 @@
     </div>
     
     <!-- Modal Container (Alpine.js) -->
-    <div x-data="{ modalOpen: false, modalContent: '' }" 
+    <div x-data="{ modalOpen: false, modalContent: '', modalTitle: 'Modal' }" 
          x-init="window.harpiModal = $refs.modal"
          class="modal-container" 
          role="dialog" 
@@ -179,11 +179,23 @@
             const toast = document.createElement('div');
             toast.className = `toast toast-${type}`;
             toast.setAttribute('role', 'alert');
-            toast.innerHTML = `
-                <span class="toast-icon">${type === 'error' ? '✕' : type === 'success' ? '✓' : 'ℹ'}</span>
-                <span class="toast-message">${message}</span>
-                <button class="toast-close" aria-label="Dismiss">✕</button>
-            `;
+            
+            const iconSpan = document.createElement('span');
+            iconSpan.className = 'toast-icon';
+            iconSpan.textContent = type === 'error' ? '✕' : type === 'success' ? '✓' : 'ℹ';
+            toast.appendChild(iconSpan);
+            
+            const msgSpan = document.createElement('span');
+            msgSpan.className = 'toast-message';
+            msgSpan.textContent = message;
+            toast.appendChild(msgSpan);
+            
+            const closeBtn = document.createElement('button');
+            closeBtn.className = 'toast-close';
+            closeBtn.setAttribute('aria-label', 'Dismiss');
+            closeBtn.textContent = '✕';
+            toast.appendChild(closeBtn);
+            
             container.appendChild(toast);
             
             // Animate in

--- a/templates/pages/dashboard.html
+++ b/templates/pages/dashboard.html
@@ -1,0 +1,95 @@
+{# templates/pages/dashboard.html #}
+{% extends "base.html" %}
+
+{% block title %}Dashboard - Harpi{% endblock %}
+
+{% block content %}
+<div class="page-transition">
+    <!-- Page Header -->
+    <header class="page-header" style="margin-bottom: var(--space-lg);">
+        <h1 class="page-title" style="font-family: var(--font-mono); font-size: 1.5rem; letter-spacing: 2px; color: var(--color-amber);">
+            <span class="page-title-icon">◢</span>
+            DASHBOARD
+        </h1>
+        <p class="page-subtitle" style="color: var(--color-text-dim); margin-top: var(--space-xs);">
+            System overview and bot status
+        </p>
+    </header>
+
+    <!-- Server Status Grid -->
+    <section aria-labelledby="status-heading" style="margin-bottom: var(--space-xl);">
+        <h2 id="status-heading" class="sr-only">Server Status</h2>
+        {% include "partials/_server_status.html" %}
+    </section>
+
+    <!-- Quick Actions -->
+    <section aria-labelledby="actions-heading" style="margin-bottom: var(--space-xl);">
+        <h2 id="actions-heading" class="panel-title" style="margin-bottom: var(--space-md);">
+            QUICK ACTIONS
+        </h2>
+        <div class="panel" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--space-md);">
+            <a class="btn btn-primary" 
+               style="justify-content: center; padding: var(--space-lg); font-size: 1rem;"
+               hx-get="{{ url_for('html_routes.music_page') }}"
+               hx-target="#main-content"
+               hx-push-url="true"
+               hx-swap="innerHTML show:window:top"
+               hx-select="#main-content > *">
+                <span style="font-size: 1.5rem;">♪</span>
+                <span>MUSIC CONTROL</span>
+            </a>
+            <a class="btn btn-secondary" 
+               style="justify-content: center; padding: var(--space-lg); font-size: 1rem;"
+               hx-get="{{ url_for('html_routes.settings_page') }}"
+               hx-target="#main-content"
+               hx-push-url="true"
+               hx-swap="innerHTML show:window:top"
+               hx-select="#main-content > *">
+                <span style="font-size: 1.5rem;">⚙</span>
+                <span>SETTINGS</span>
+            </a>
+            <button class="btn btn-secondary" 
+                    hx-post="{{ url_for('htmx_routes.api_bot_restart') }}"
+                    hx-target="#toast-container"
+                    hx-swap="beforeend"
+                    hx-confirm="Restart the bot?"
+                    style="justify-content: center; padding: var(--space-lg); font-size: 1rem;">
+                <span>RESTART BOT</span>
+            </button>
+            <button class="btn btn-danger" 
+                    hx-post="{{ url_for('htmx_routes.api_bot_shutdown') }}"
+                    hx-target="#toast-container"
+                    hx-swap="beforeend"
+                    hx-confirm="Shutdown the bot completely?"
+                    style="justify-content: center; padding: var(--space-lg); font-size: 1rem;">
+                <span>SHUTDOWN</span>
+            </button>
+        </div>
+    </section>
+
+    <!-- Bot Info -->
+    <section aria-labelledby="bot-info-heading">
+        <h2 id="bot-info-heading" class="panel-title" style="margin-bottom: var(--space-md);">
+            BOT INFORMATION
+        </h2>
+        <div class="panel" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: var(--space-md);">
+            <div>
+                <div style="font-family: var(--font-mono); font-size: 0.7rem; color: var(--color-text-dim); text-transform: uppercase; margin-bottom: var(--space-xs);">BOT USER</div>
+                <div style="font-family: var(--font-mono); font-size: 1rem; color: var(--color-text);">{{ bot_user }}</div>
+            </div>
+            <div>
+                <div style="font-family: var(--font-mono); font-size: 0.7rem; color: var(--color-text-dim); text-transform: uppercase; margin-bottom: var(--space-xs);">BOT ID</div>
+                <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--color-text);">{{ bot_id }}</div>
+            </div>
+            <div>
+                <div style="font-family: var(--font-mono); font-size: 0.7rem; color: var(--color-text-dim); text-transform: uppercase; margin-bottom: var(--space-xs);">DISCORD.PY VERSION</div>
+                <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--color-text);">{{ discord_version }}</div>
+            </div>
+            <div>
+                <div style="font-family: var(--font-mono); font-size: 0.7rem; color: var(--color-text-dim); text-transform: uppercase; margin-bottom: var(--space-xs);">PYTHON VERSION</div>
+                <div style="font-family: var(--font-mono); font-size: 0.85rem; color: var(--color-text);">{{ python_version }}</div>
+            </div>
+        </div>
+    </section>
+</div>
+{% endblock %}

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -1,0 +1,63 @@
+{# templates/pages/settings.html #}
+{% extends "base.html" %}
+
+{% block title %}Settings - Harpi{% endblock %}
+
+{% block content %}
+<div class="page-transition settings-layout">
+    <!-- Settings Navigation -->
+    <nav class="settings-nav" aria-label="Settings sections">
+        <ul class="settings-nav-list" role="list">
+            <li>
+                <button class="settings-nav-item active" 
+                        hx-get="{{ url_for('htmx_routes.htmx_settings_section', section='general') }}"
+                        hx-target="#settings-content"
+                        hx-swap="innerHTML"
+                        hx-push-url="false"
+                        aria-label="General settings">
+                    <span class="settings-nav-icon">⚙</span>
+                    <span>GENERAL</span>
+                </button>
+            </li>
+            <li>
+                <button class="settings-nav-item"
+                        hx-get="{{ url_for('htmx_routes.htmx_settings_section', section='music') }}"
+                        hx-target="#settings-content"
+                        hx-swap="innerHTML"
+                        hx-push-url="false"
+                        aria-label="Music settings">
+                    <span class="settings-nav-icon">♪</span>
+                    <span>MUSIC</span>
+                </button>
+            </li>
+            <li>
+                <button class="settings-nav-item"
+                        hx-get="{{ url_for('htmx_routes.htmx_settings_section', section='tts') }}"
+                        hx-target="#settings-content"
+                        hx-swap="innerHTML"
+                        hx-push-url="false"
+                        aria-label="TTS settings">
+                    <span class="settings-nav-icon">♪</span>
+                    <span>TTS</span>
+                </button>
+            </li>
+            <li>
+                <button class="settings-nav-item"
+                        hx-get="{{ url_for('htmx_routes.htmx_settings_section', section='dice') }}"
+                        hx-target="#settings-content"
+                        hx-swap="innerHTML"
+                        hx-push-url="false"
+                        aria-label="Dice settings">
+                    <span class="settings-nav-icon">◆</span>
+                    <span>DICE</span>
+                </button>
+            </li>
+        </ul>
+    </nav>
+
+    <!-- Settings Content -->
+    <div class="settings-content" id="settings-content">
+        {% include "partials/_settings_general.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/pages/settings.html
+++ b/templates/pages/settings.html
@@ -37,7 +37,7 @@
                         hx-swap="innerHTML"
                         hx-push-url="false"
                         aria-label="TTS settings">
-                    <span class="settings-nav-icon">♪</span>
+                    <span class="settings-nav-icon">≡</span>
                     <span>TTS</span>
                 </button>
             </li>

--- a/templates/partials/_playback_controls.html
+++ b/templates/partials/_playback_controls.html
@@ -1,0 +1,140 @@
+{# templates/partials/_playback_controls.html #}
+<div class="playback-panel" id="playback-controls"
+     hx-get="{{ url_for('htmx_routes.htmx_playback_controls', guild_id=guild_id) }}"
+      hx-trigger="every 2s, playbackUpdated from:body"
+     hx-swap="outerHTML"
+     hx-indicator="#playback-loading">
+
+    <div class="playback-main">
+        <button class="playback-btn btn-prev"
+                hx-post="{{ url_for('htmx_routes.api_music_previous', guild_id=guild_id) }}"
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="Previous track"
+                title="Previous">
+            ⏮
+        </button>
+
+        <button class="playback-btn btn-rewind"
+                hx-post="{{ url_for('htmx_routes.api_music_seek', guild_id=guild_id) }}"
+                hx-vals='{"position": -10}'
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="Rewind 10 seconds"
+                title="Rewind 10s">
+            ⏪
+        </button>
+
+        <button class="playback-btn play {% if paused %}paused{% endif %}"
+                hx-post="{{ url_for('htmx_routes.api_music_toggle_pause', guild_id=guild_id) }}"
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="{% if paused %}Resume{% else %}Pause{% endif %}"
+                title="{% if paused %}Resume{% else %}Pause{% endif %}">
+            {% if paused %}▶{% else %}⏸{% endif %}
+        </button>
+
+        <button class="playback-btn btn-forward"
+                hx-post="{{ url_for('htmx_routes.api_music_seek', guild_id=guild_id) }}"
+                hx-vals='{"position": 10}'
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="Forward 10 seconds"
+                title="Forward 10s">
+            ⏩
+        </button>
+
+        <button class="playback-btn btn-next"
+                hx-post="{{ url_for('htmx_routes.api_music_skip', guild_id=guild_id) }}"
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="Next track"
+                title="Next">
+            ⏭
+        </button>
+
+        <button class="playback-btn btn-stop"
+                hx-post="{{ url_for('htmx_routes.api_music_stop', guild_id=guild_id) }}"
+                hx-target="#playback-controls"
+                hx-swap="outerHTML"
+                aria-label="Stop playback"
+                title="Stop">
+            ⏹
+        </button>
+    </div>
+
+    <div class="playback-progress">
+        <div class="playback-time">
+            <span class="playback-current-time">{{ current_position_formatted }}</span>
+            <span class="playback-total-time">{{ current_track.duration | format_duration if current_track else '0:00' }}</span>
+        </div>
+        <div class="progress"
+             hx-post="{{ url_for('htmx_routes.api_music_seek', guild_id=guild_id) }}"
+             hx-vals='js:{position: Math.round(event.offsetX / this.offsetWidth * 100)}'
+             hx-trigger="click"
+             hx-target="#playback-controls"
+             hx-swap="outerHTML"
+             role="slider"
+             aria-label="Playback progress"
+             aria-valuemin="0"
+             aria-valuemax="100"
+             aria-valuenow="{{ (current_position / 1000 / (current_track.duration if current_track else 1) * 100) | round if current_track and current_track.duration else 0 }}">
+            <div class="progress-bar" style="width: {{ (current_position / 1000 / (current_track.duration if current_track else 1) * 100) | round if current_track and current_track.duration else 0 }}%"></div>
+        </div>
+    </div>
+
+    <div class="playback-volume">
+        <label for="master-volume" class="sr-only">Master volume</label>
+        <span class="volume-icon">VOL</span>
+        <input type="range"
+               id="master-volume"
+               class="volume-slider"
+               min="0" max="1" step="0.05"
+               value="{{ volume | default(0.5) }}"
+               hx-post="{{ url_for('htmx_routes.api_music_volume', guild_id=guild_id) }}"
+               hx-vals='js:{volume: this.value}'
+               hx-trigger="change"
+               hx-target="#playback-controls"
+               hx-swap="outerHTML"
+               aria-label="Master volume">
+        <span class="volume-text">{{ (volume | default(0.5) * 100) | round }}%</span>
+    </div>
+
+    <div class="playback-secondary">
+        <div class="playback-mode">
+            <span class="mode-label">LOOP:</span>
+            <button class="playback-mode-btn {% if loop_mode == 'off' %}active{% endif %}"
+                    hx-post="{{ url_for('htmx_routes.api_music_loop', guild_id=guild_id, mode='off') }}"
+                    hx-target="#playback-controls"
+                    hx-swap="outerHTML"
+                    aria-label="Loop off"
+                    title="Off">OFF</button>
+            <button class="playback-mode-btn {% if loop_mode == 'track' %}active{% endif %}"
+                    hx-post="{{ url_for('htmx_routes.api_music_loop', guild_id=guild_id, mode='track') }}"
+                    hx-target="#playback-controls"
+                    hx-swap="outerHTML"
+                    aria-label="Loop track"
+                    title="Track">TRACK</button>
+            <button class="playback-mode-btn {% if loop_mode == 'queue' %}active{% endif %}"
+                    hx-post="{{ url_for('htmx_routes.api_music_loop', guild_id=guild_id, mode='queue') }}"
+                    hx-target="#playback-controls"
+                    hx-swap="outerHTML"
+                    aria-label="Loop queue"
+                    title="Queue">QUEUE</button>
+        </div>
+
+        <div class="playback-info">
+            {% if current_track %}
+            <div class="playback-info-item">
+                <span class="info-label">VOL:</span>
+                <span class="info-value">{{ (volume | default(0.5) * 100) | round }}%</span>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Loading indicator -->
+    <div id="playback-loading" class="htmx-indicator" style="display:flex;justify-content:center;padding:16px;">
+        <div class="spinner"></div>
+    </div>
+</div>

--- a/templates/partials/_playback_controls.html
+++ b/templates/partials/_playback_controls.html
@@ -126,8 +126,8 @@
         <div class="playback-info">
             {% if current_track %}
             <div class="playback-info-item">
-                <span class="info-label">VOL:</span>
-                <span class="info-value">{{ (volume | default(0.5) * 100) | round }}%</span>
+                <span class="info-label">TRACK:</span>
+                <span class="info-value">{{ current_track.title | truncate(30) }}</span>
             </div>
             {% endif %}
         </div>

--- a/templates/partials/_server_status.html
+++ b/templates/partials/_server_status.html
@@ -1,0 +1,96 @@
+{# templates/partials/_server_status.html #}
+{# Standalone server status grid for HTMX polling #}
+<div class="status-grid" id="server-status-grid"
+     hx-get="{{ url_for('htmx_routes.htmx_server_status') }}"
+      hx-trigger="every 5s"
+     hx-swap="outerHTML"
+     hx-indicator="#status-loading">
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">CPU USAGE</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value">{{ cpu_percent | round(1) }}</span>
+            <span class="unit">%</span>
+        </div>
+        <div class="status-card-bar">
+            <div class="progress">
+                <div class="progress-bar {% if cpu_percent > 80 %}error{% elif cpu_percent > 60 %}warning{% endif %}"
+                     style="width: {{ cpu_percent | round }}%"></div>
+            </div>
+        </div>
+    </div>
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">MEMORY</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value">{{ memory_percent | round(1) }}</span>
+            <span class="unit">%</span>
+        </div>
+        <div class="status-card-bar">
+            <div class="progress">
+                <div class="progress-bar {% if memory_percent > 85 %}error{% elif memory_percent > 70 %}warning{% endif %}"
+                     style="width: {{ memory_percent | round }}%"></div>
+            </div>
+        </div>
+        <div class="status-card-detail" style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: var(--space-sm);">
+            {{ memory_used | format_bytes }} / {{ memory_total | format_bytes }}
+        </div>
+    </div>
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">BOT STATUS</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value status-text" style="font-size: 1.5rem; {% if bot_connected %}color: var(--color-success);{% else %}color: var(--color-error);{% endif %}">
+                {% if bot_connected %}ONLINE{% else %}OFFLINE{% endif %}
+            </span>
+        </div>
+        <div class="status-card-detail" style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: var(--space-sm);">
+            Latency: <span style="color: var(--color-amber);">{{ "%.0f" | format(bot_latency) }}ms</span>
+        </div>
+    </div>
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">GUILDS</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value">{{ guild_count }}</span>
+        </div>
+        <div class="status-card-detail" style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: var(--space-sm);">
+            Users: {{ user_count }}
+        </div>
+    </div>
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">MUSIC</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value">{{ music_guilds }}</span>
+            <span class="unit">ACTIVE</span>
+        </div>
+        <div class="status-card-detail" style="font-size: 0.75rem; color: var(--color-text-muted); margin-top: var(--space-sm);">
+            Queue: {{ queue_total }} tracks
+        </div>
+    </div>
+
+    <div class="status-card">
+        <div class="status-card-header">
+            <div class="status-card-title">UPTIME</div>
+        </div>
+        <div class="status-card-value">
+            <span class="value" style="font-size: 1.5rem;">{{ uptime_formatted }}</span>
+        </div>
+    </div>
+
+    <!-- Loading indicator -->
+    <div id="status-loading" class="htmx-indicator" style="display:flex;justify-content:center;padding:16px;">
+        <div class="spinner spinner-lg"></div>
+    </div>
+</div>

--- a/templates/partials/_settings_general.html
+++ b/templates/partials/_settings_general.html
@@ -1,0 +1,79 @@
+{# templates/partials/_settings_general.html #}
+<div class="settings-section">
+    <h3 class="settings-section-title">GENERAL SETTINGS</h3>
+
+    <div class="settings-form-row">
+        <div class="form-group">
+            <label class="form-label" for="prefix">COMMAND PREFIX</label>
+            <input type="text" 
+                   id="prefix"
+                   class="form-input" 
+                   value="{{ config.prefix | default(config.DEFAULT_PREFIX) }}"
+                   hx-post="{{ url_for('htmx_routes.api_settings_update', section='general') }}"
+                   hx-vals='js:{prefix: this.value}'
+                   hx-trigger="change"
+                   hx-target="#toast-container"
+                   hx-swap="beforeend"
+                   placeholder="!">
+            <span class="form-help">The prefix used before bot commands (e.g., !play)</span>
+        </div>
+
+        <div class="form-group">
+            <label class="form-label" for="language">LANGUAGE</label>
+            <select id="language" 
+                    class="form-select"
+                    hx-post="{{ url_for('htmx_routes.api_settings_update', section='general') }}"
+                    hx-vals='js:{language: this.value}'
+                    hx-trigger="change"
+                    hx-target="#toast-container"
+                    hx-swap="beforeend">
+                <option value="en" {% if config.language == 'en' %}selected{% endif %}>English</option>
+                <option value="pt-BR" {% if config.language == 'pt-BR' %}selected{% endif %}>Português (Brasil)</option>
+            </select>
+            <span class="form-help">Bot response language</span>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="form-check">
+            <input type="checkbox" 
+                   id="auto-connect"
+                   class="form-check-input"
+                   {% if config.auto_connect %}checked{% endif %}
+                   hx-post="{{ url_for('htmx_routes.api_settings_update', section='general') }}"
+                   hx-vals='js:{auto_connect: this.checked}'
+                   hx-trigger="change"
+                   hx-target="#toast-container"
+                   hx-swap="beforeend">
+            <label class="form-check-label" for="auto-connect">Auto-connect to voice on startup</label>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <div class="form-check">
+            <input type="checkbox" 
+                   id="debug-mode"
+                   class="form-check-input"
+                   {% if config.debug_mode %}checked{% endif %}
+                   hx-post="{{ url_for('htmx_routes.api_settings_update', section='general') }}"
+                   hx-vals='js:{debug_mode: this.checked}'
+                   hx-trigger="change"
+                   hx-target="#toast-container"
+                   hx-swap="beforeend">
+            <label class="form-check-label" for="debug-mode">Debug mode (verbose logging)</label>
+        </div>
+    </div>
+</div>
+
+<div class="settings-section">
+    <h3 class="settings-section-title">ABOUT</h3>
+    <div class="panel" style="padding: var(--space-md); font-size: 0.85rem; color: var(--color-text-dim);">
+        <p><strong>Harpi</strong> - TTRPG Discord Bot v{{ version }}</p>
+        <p style="margin-top: var(--space-sm);">
+            The most complete Discord Bot for TTRPG sessions. Music, TTS, dice rolls, and more.
+        </p>
+        <p style="margin-top: var(--space-sm);">
+            Made by SmileyDroid
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Fixes

### SMI-35: Duplicate Navigation Bar
- Removed duplicate `guild-channel-selector` wrapper div in `base.html` (the partial already wraps itself)
- Added `hx-select="#main-content > *"` to all HTMX nav links and quick action buttons to prevent full-page HTML (including the header) from being injected into `#main-content`

### SMI-36: Emoji Cleanup
- Removed all emoji characters from status cards, quick actions, and settings panels
- Replaced volume emoji with "VOL" text label
- Differentiated TTS icon using ≡ symbol (distinct from Music's ♪)
- Removed heart emoji from About section

### Review Fixes Applied
- Fixed Alpine.js modalTitle bug (was missing from x-data declaration)
- Fixed showToast XSS vulnerability (innerHTML → textContent)
- Removed duplicate volume display in playback controls, now shows track title
- Used different symbol for TTS (≡) to distinguish from Music (♪)